### PR TITLE
Allow resolving things other than A records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ all: lint test
 
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
-		--reporter $(REPORTER)
+		--reporter $(REPORTER) \
+		--timeout 10000
 
 lint:
 	$(JSHINT) index.js --config $(BASE)/.jshintrc && \

--- a/lib/dns-sync.js
+++ b/lib/dns-sync.js
@@ -17,6 +17,9 @@ function isValidHostName(hostname) {
  * returns null in case of error
  */
 module.exports = {
+    lookup: function lookup(hostname) {
+        return module.exports.resolve(hostname);
+    },
     resolve: function resolve(hostname, type) {
         var output,
             nodeBinary = process.execPath;

--- a/lib/dns-sync.js
+++ b/lib/dns-sync.js
@@ -17,7 +17,7 @@ function isValidHostName(hostname) {
  * returns null in case of error
  */
 module.exports = {
-    resolve: function resolve(hostname) {
+    resolve: function resolve(hostname, type) {
         var output,
             nodeBinary = process.execPath;
 
@@ -28,14 +28,12 @@ module.exports = {
 
         var scriptPath = path.join(__dirname, "../scripts/dns-lookup-script"),
             response,
-            cmd = util.format('"%s" "%s" %s', nodeBinary, scriptPath, hostname);
+            cmd = util.format('"%s" "%s" %s %s', nodeBinary, scriptPath, hostname, type);
 
         response = shell.exec(cmd, {silent: true});
         if (response && response.code === 0) {
             output = response.output;
-            if (output && net.isIP(output)) {
-                return output;
-            }
+            return JSON.parse(output);
         }
         debug('hostname', "fail to resolve hostname " + hostname);
         return null;

--- a/lib/dns-sync.js
+++ b/lib/dns-sync.js
@@ -31,12 +31,11 @@ module.exports = {
 
         var scriptPath = path.join(__dirname, "../scripts/dns-lookup-script"),
             response,
-            cmd = util.format('"%s" "%s" %s %s', nodeBinary, scriptPath, hostname, type);
+            cmd = util.format('"%s" "%s" %s %s', nodeBinary, scriptPath, hostname, type || '');
 
         response = shell.exec(cmd, {silent: true});
         if (response && response.code === 0) {
-            output = response.output;
-            return JSON.parse(output);
+            return JSON.parse(response.output);
         }
         debug('hostname', "fail to resolve hostname " + hostname);
         return null;

--- a/scripts/dns-lookup-script.js
+++ b/scripts/dns-lookup-script.js
@@ -1,19 +1,22 @@
 'use strict';
 
 var dns = require('dns'),
-    debug = require('debug')('dns-sync');
+    debug = require('debug')('dns-sync'),
+    name, type, fn;
 
 for (var i = 0; i < process.argv.length; i++) {
 	if (process.argv[i].indexOf('dns-lookup-script') >= 0) {
-		var name = process.argv[i + 1];
-		var type = process.argv[i + 2] || 'A';
+		name = process.argv[i + 1];
+		type = process.argv[i + 2];
+		fn = type ? dns.resolve.bind(dns, name, type) : dns.lookup.bind(dns, name);
+		break;
 	}
 }
 
-dns.resolve(name, type, function (err, ip) {
+fn(function (err, ip) {
     if (err) {
-        process.exit(1);
         debug(err);
+        process.exit(1);
     } else {
         debug(name, 'resolved to', ip);
         process.stdout.write(JSON.stringify(ip));

--- a/scripts/dns-lookup-script.js
+++ b/scripts/dns-lookup-script.js
@@ -1,15 +1,21 @@
 'use strict';
 
 var dns = require('dns'),
-    name = process.argv[2],
     debug = require('debug')('dns-sync');
 
-dns.lookup(name, function (err, ip) {
+for (var i = 0; i < process.argv.length; i++) {
+	if (process.argv[i].indexOf('dns-lookup-script') >= 0) {
+		var name = process.argv[i + 1];
+		var type = process.argv[i + 2] || 'A';
+	}
+}
+
+dns.resolve(name, type, function (err, ip) {
     if (err) {
         process.exit(1);
         debug(err);
     } else {
         debug(name, 'resolved to', ip);
-        process.stdout.write(ip);
+        process.stdout.write(JSON.stringify(ip));
     }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -24,4 +24,18 @@ describe('dns sync', function () {
         assert.ok(!dnsSync.resolve("cd /tmp; rm -f /tmp/echo; env 'x=() { (a)=>\' bash -c \"echo date\"; cat /tmp/echo"));
         assert.ok(!dnsSync.resolve("$(grep -l -z '[^)]=() {' /proc/[1-9]*/environ | cut -d/ -f3)'"));
     });
+
+    it('should resolve AAAA records if asked', function () {
+        var aaaa = dnsSync.resolve('www.google.com', 'AAAA');
+        assert.ok(aaaa);
+        assert.ok(aaaa[0].match(/^([0-9a-f]{2,4}(:|$))+/));
+        assert.ok(dnsSync.resolve('www.google.com') !== aaaa);
+    });
+
+    it('should resolve NS records if asked', function () {
+        var ns = dnsSync.resolve('google.com', 'NS')
+        assert.ok(ns);
+        assert.ok(ns.length >= 1);
+        assert.ok(ns[0].match(/^ns[0-9]+\.google\.com$/));
+    }); 
 });


### PR DESCRIPTION
This allows resolution of TXT records and other non-A/AAAA records.

It also uses JSON.stringify/parse to pass data back from the subprocess.

Finally it uses some automated guessing on the argv values, that was causing an issue with testing